### PR TITLE
Ghost Mode Init Commit

### DIFF
--- a/src/main/java/frc/team1836/robot/auto/actions/GhostAction.java
+++ b/src/main/java/frc/team1836/robot/auto/actions/GhostAction.java
@@ -1,0 +1,43 @@
+package frc.team1836.robot.auto.actions;
+
+import frc.team1836.robot.subsystems.Drive;
+import frc.team1836.robot.util.auto.Action;
+
+public class GhostAction implements Action {
+
+	/**
+	 * Returns whether or not the code has finished execution. When implementing this interface, this method is used by
+	 * the runAction method every cycle to know when to stop running the action
+	 *
+	 * @return boolean
+	 */
+	@Override
+	public boolean isFinished() {
+		return Drive.getInstance().isGhostOver();
+	}
+
+	/**
+	 * Called by runAction in AutoModeBase iteratively until isFinished returns true. Iterative logic lives in this
+	 * method
+	 */
+	@Override
+	public void update() {
+		Drive.getInstance().updateGhostMode();
+	}
+
+	/**
+	 * Run code once when the action finishes, usually for clean up
+	 */
+	@Override
+	public void done() {
+
+	}
+
+	/**
+	 * Run code once when the action is started, for set up
+	 */
+	@Override
+	public void start() {
+		Drive.getInstance().setGhostMode();
+	}
+}

--- a/src/main/java/frc/team1836/robot/auto/modes/GhostMode.java
+++ b/src/main/java/frc/team1836/robot/auto/modes/GhostMode.java
@@ -1,0 +1,16 @@
+package frc.team1836.robot.auto.modes;
+
+import frc.team1836.robot.auto.actions.GhostAction;
+import frc.team1836.robot.util.auto.AutoModeBase;
+import frc.team1836.robot.util.auto.AutoModeEndedException;
+
+public class GhostMode extends AutoModeBase {
+
+
+	@Override
+	protected void routine() throws AutoModeEndedException {
+		System.out.println("Starting Ghost Mode... Done!");
+		runAction(new GhostAction());
+	}
+
+}


### PR DESCRIPTION
Bad Idea or Cool Feature? Currently just put all the Drive Signals in a hashmap in memory so will have to go straight from teleop to auto without rebooting code, but if it works well I'll just somehow stick the setpoints from my csv log into a java class like is done for paths. The hope is to have a driver just drive, and be able to recreate the movement in auto.