### PR TITLE
Update Feedforward during Path Following

### DIFF
--- a/src/main/java/frc/team1836/robot/subsystems/Drive.java
+++ b/src/main/java/frc/team1836/robot/subsystems/Drive.java
@@ -68,6 +68,8 @@ public class Drive extends Subsystem {
 
 	public synchronized void setVelocitySetpoint(DriveSignal signal) {
 		if (RobotState.mDriveControlState == DriveControlState.PATH_FOLLOWING) {
+			leftDrive.updateFeedforward(1023.0 / signal.getLeftNativeVelTraj());
+			rightDrive.updateFeedforward(1023.0 / signal.getRightNativeVelTraj());
 			leftDrive.set(ControlMode.Velocity, signal.getLeftNativeVelTraj());
 			rightDrive.set(ControlMode.Velocity, signal.getRightNativeVelTraj());
 		} else {
@@ -75,7 +77,6 @@ public class Drive extends Subsystem {
 			leftDrive.set(ControlMode.Velocity, signal.getLeftNativeVel());
 			rightDrive.set(ControlMode.Velocity, signal.getRightNativeVel());
 		}
-
 		currentSetpoint = signal;
 	}
 

--- a/src/main/java/frc/team1836/robot/util/drivers/MkDrive.java
+++ b/src/main/java/frc/team1836/robot/util/drivers/MkDrive.java
@@ -55,6 +55,10 @@ public class MkDrive {
 		slaveTalon.set(ControlMode.Follower, masterID);
 	}
 
+	public void updateFeedforward(double feed) {
+		masterTalon.config_kF(DRIVE.kPIDLoopIdx, feed, 0);
+	}
+
 	public double getError() {
 		return nativeUnitsToInches(masterTalon.getClosedLoopError(DRIVE.kPIDLoopIdx));
 	}

--- a/src/main/java/frc/team254/lib/trajectory/TrajectoryFollower.java
+++ b/src/main/java/frc/team254/lib/trajectory/TrajectoryFollower.java
@@ -56,7 +56,7 @@ public class TrajectoryFollower {
 			double angError = segment.heading - heading;
 			double velError = segment.vel - vel;
 			double desired = (angError * kAng_) + segment.vel;
-			double output = desired + (kp_ * error) + (kv_ * segment.vel) + (ka_ * segment.acc);
+			double output = desired + (kp_ * error) + (ka_ * segment.acc);
 
 			last_error_ = error;
 			last_Ang_error = angError;


### PR DESCRIPTION
> Currently you should be able to config_kF(value,0) in your robot loop. Knowing what your target is, you can reverse calc what kF to pass to add an arbitrary desired offset.
Generally adding one or two Configs in the robot loop does not impact performance. Pass 0 for the timeout so that you don't wait for confirmation. Since you would be periodically changing kF, there is no need to block for confirmation.
It's not clear when that will be added, so for the time being I would use the config_kF method. I believe the optimizations we've done to to rest of the API will make up for it.
Watch you CAN bus util and keep it <80/90%
A single config every ~20ms (robot loop) should not be a problem. 

CTRE^^
Not sure how it'll work updating this quickly (whether I should wait a few cycles before updating?), and also not sure whether my feedforward equation is even right. 